### PR TITLE
New template for gen_statem behavior added in OTP 19

### DIFF
--- a/doc/vim-erlang-skeletons.txt
+++ b/doc/vim-erlang-skeletons.txt
@@ -22,6 +22,8 @@ COMMANDS                                        *ErlangSkeletonsCommands*
 :ErlServer              Loads gen_server template into current buffer.
                                                 *ErlFsm*
 :ErlFsm                 Loads gen_fsm template into current buffer.
+                                                *ErlStatem*
+:ErlStatem              Loads gen_statem template into current buffer.
                                                 *ErlSupervisor*
 :ErlSupervisor          Loads supervisor template into current buffer.
                                                 *ErlEvent*

--- a/plugin/templates/gen_statem
+++ b/plugin/templates/gen_statem
@@ -44,7 +44,7 @@ start_link() ->
     gen_statem:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 %%%===================================================================
-%%% gen_fsm callbacks
+%%% gen_statem callbacks
 %%%===================================================================
 
 %%--------------------------------------------------------------------
@@ -73,7 +73,7 @@ init([]) ->
 %% @spec format_status(Opt, [PDict, StateName, State]) -> term()
 %% @end
 %%--------------------------------------------------------------------
-format_status(_Opt, [_PDict, _State, _Data]) ->
+format_status(_Opt, [_PDict, _StateName, _State]) ->
     Status = some_term,
     Status.
 
@@ -87,16 +87,22 @@ format_status(_Opt, [_PDict, _State, _Data]) ->
 %%
 %% @spec state_name(Event, From, State) ->
 %%                   {next_state, NextStateName, NextState} |
-%%                   {next_state, NextStateName, NextState, Timeout} |
-%%                   {reply, Reply, NextStateName, NextState} |
-%%                   {reply, Reply, NextStateName, NextState, Timeout} |
+%%                   {next_state, NextStateName, NextState, Actions} |
 %%                   {stop, Reason, NewState} |
-%%                   {stop, Reason, Reply, NewState}
+%%    				 stop |
+%%                   {stop, Reason :: term()} |
+%%                   {stop, Reason :: term(), NewData :: data()} |
+%%                   {stop_and_reply, Reason, Replies} |
+%%                   {stop_and_reply, Reason, Replies, NewState} |
+%%                   {keep_state, NewData :: data()} |
+%%                   {keep_state, NewState, Actions} |
+%%                   keep_state_and_data |
+%%                   {keep_state_and_data, Actions}
 %% @end
 %%--------------------------------------------------------------------
 state_name(_EventType, _EventContent, State) ->
-    Reply = ok,
-    {reply, Reply, state_name, State}.
+    NextStateName = next_state,
+    {next_state, NextStateName, State}.
 
 %%--------------------------------------------------------------------
 %% @private

--- a/plugin/templates/gen_statem
+++ b/plugin/templates/gen_statem
@@ -1,0 +1,156 @@
+%%%-------------------------------------------------------------------
+%%% @author $author
+%%% @copyright (C) $year, $company
+%%% @doc
+%%%
+%%% @end
+%%% Created : $fulldate
+%%%-------------------------------------------------------------------
+-module($basename).
+
+-behaviour(gen_statem).
+
+%% API
+-export([start_link/0]).
+
+%% gen_statem callbacks
+-export([
+         init/1,
+         format_status/2,
+         state_name/3,
+         handle_event/4,
+         terminate/3,
+         code_change/4
+        ]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Creates a gen_statem process which calls Module:init/1 to
+%% initialize. To ensure a synchronized start-up procedure, this
+%% function does not return until Module:init/1 has returned.
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link() ->
+    gen_statem:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_fsm callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Whenever a gen_statem is started using gen_statem:start/[3,4] or
+%% gen_statem:start_link/[3,4], this function is called by the new
+%% process to initialize.
+%%
+%% @spec init(Args) -> {CallbackMode, StateName, State} |
+%%                     {CallbackMode, StateName, State, Actions} |
+%%                     ignore |
+%%                     {stop, StopReason}
+%% @end
+%%--------------------------------------------------------------------
+init([]) ->
+    {ok, state_name, #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Called (1) whenever sys:get_status/1,2 is called by gen_statem or
+%% (2) when gen_statem terminates abnormally.
+%% This callback is optional.
+%%
+%% @spec format_status(Opt, [PDict, StateName, State]) -> term()
+%% @end
+%%--------------------------------------------------------------------
+format_status(_Opt, [_PDict, _State, _Data]) ->
+    Status = some_term,
+    Status.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% There should be one instance of this function for each possible
+%% state name.  If callback_mode is statefunctions, one of these
+%% functions is called when gen_statem receives and event from
+%% call/2, cast/2, or as a normal process message.
+%%
+%% @spec state_name(Event, From, State) ->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, Timeout} |
+%%                   {reply, Reply, NextStateName, NextState} |
+%%                   {reply, Reply, NextStateName, NextState, Timeout} |
+%%                   {stop, Reason, NewState} |
+%%                   {stop, Reason, Reply, NewState}
+%% @end
+%%--------------------------------------------------------------------
+state_name(_EventType, _EventContent, State) ->
+    Reply = ok,
+    {reply, Reply, state_name, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% If callback_mode is handle_event_function, then whenever a
+%% gen_statem receives an event from call/2, cast/2, or as a normal
+%% process message, this function is called.
+%%
+%% @spec handle_event(Event, StateName, State) ->
+%%                   {next_state, NextStateName, NextState} |
+%%                   {next_state, NextStateName, NextState, Actions} |
+%%                   {stop, Reason, NewState} |
+%%    				 stop |
+%%                   {stop, Reason :: term()} |
+%%                   {stop, Reason :: term(), NewData :: data()} |
+%%                   {stop_and_reply, Reason, Replies} |
+%%                   {stop_and_reply, Reason, Replies, NewState} |
+%%                   {keep_state, NewData :: data()} |
+%%                   {keep_state, NewState, Actions} |
+%%                   keep_state_and_data |
+%%                   {keep_state_and_data, Actions}
+%% @end
+%%--------------------------------------------------------------------
+handle_event(_EventType, _EventContent, _StateName, State) ->
+    NextStateName = the_next_state_name,
+    {next_state, NextStateName, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_statem when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_statem terminates with
+%% Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, StateName, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, StateName, State, Extra) ->
+%%                   {ok, StateName, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, StateName, State, _Extra) ->
+    {ok, StateName, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/plugin/vim-erlang-skeletons.vim
+++ b/plugin/vim-erlang-skeletons.vim
@@ -58,6 +58,7 @@ endfunction
 
 command! -nargs=0 ErlServer      call LoadTemplate("gen_server")
 command! -nargs=0 ErlFsm         call LoadTemplate("gen_fsm")
+command! -nargs=0 ErlStatem      call LoadTemplate("gen_statem")
 command! -nargs=0 ErlSupervisor  call LoadTemplate("supervisor")
 command! -nargs=0 ErlEvent       call LoadTemplate("gen_event")
 command! -nargs=0 ErlApplication call LoadTemplate("application")


### PR DESCRIPTION
This new template needs checking.  But at the least, it contains the required new code and eliminates the need for a good bit of grunt work.