### PR TITLE
Respect pythonx, prefer python3 to python2.

### DIFF
--- a/plugin/vim-erlang-skeletons.vim
+++ b/plugin/vim-erlang-skeletons.vim
@@ -1,7 +1,9 @@
-if has('python')
-    let s:pyfile = 'pyfile '
+if has('pythonx')
+    let s:pyfile = 'pyxfile '
 elseif has('python3')
     let s:pyfile = 'py3file '
+elseif has('python')
+    let s:pyfile = 'pyfile '
 else
     echo "Error: Required vim compiled with +python or +python3"
     finish


### PR DESCRIPTION
If vim supports both python 2 and python 3 (`+python/dyn`, `+python3/dyn`), this will load python2, stopping vim from running python3.

`has('python')`  and similar will attempt to load the relevant dynamic library, so the order of the checks affect which is loaded when both are supported. Once loaded, a second python runtime cannot be linked, so globally sets the available python version to 2 (explained more effectively `:h has-python`).

This changes the default order to checking for python3 then python2, with `pythonx` allowing the user to set a preferred version.